### PR TITLE
Fix paragraph direction

### DIFF
--- a/scribus/scribusdoc.cpp
+++ b/scribus/scribusdoc.cpp
@@ -11700,11 +11700,6 @@ void ScribusDoc::itemSelection_SetDirection(int s, Selection* customSelection)
 {
 	ParagraphStyle newStyle;
 	newStyle.setDirection(static_cast<ParagraphStyle::DirectionType>(s));
-	if (s == 0)
-		newStyle.setAlignment(static_cast<ParagraphStyle::AlignmentType>(0));
-	else if (s == 1)
-		newStyle.setAlignment(static_cast<ParagraphStyle::AlignmentType>(2));
-
 	itemSelection_ApplyParagraphStyle(newStyle, customSelection);
 }
 

--- a/scribus/ui/alignselect.h
+++ b/scribus/ui/alignselect.h
@@ -39,8 +39,6 @@ public:
 
 public slots:
 	void languageChange();
-		
-private slots:
 	void setTypeStyle(int a);
 
 signals:

--- a/scribus/ui/propertiespalette_text.cpp
+++ b/scribus/ui/propertiespalette_text.cpp
@@ -613,6 +613,18 @@ void PropertiesPalette_Text::handleDirection(int a)
 	Selection tempSelection(this, false);
 	tempSelection.addItem(m_item, true);
 	m_doc->itemSelection_SetDirection(a, &tempSelection);
+	//set alignment to RTL if direction is RTL
+	if (a == 0 && textAlignment->selectedId() == 2)
+	{
+		m_doc->itemSelection_SetAlignment(0, &tempSelection);
+		textAlignment->setTypeStyle(0);
+	}
+	//set alignment to LTR if direction is LTR
+	if (a == 1 && textAlignment->selectedId() == 0)
+	{
+		m_doc->itemSelection_SetAlignment(2, &tempSelection);
+		textAlignment->setTypeStyle(2);
+	}
 }
 
 void PropertiesPalette_Text::handleTextFont(QString c)


### PR DESCRIPTION
Not allowing direction to change alignment when paragraph is aligned center or justified.
