### PR TITLE
Fix resize text frame change the last line alignment

### DIFF
--- a/scribus/pageitem_textframe.cpp
+++ b/scribus/pageitem_textframe.cpp
@@ -2894,8 +2894,8 @@ void PageItem_TextFrame::layout()
 			}
 			else // #11727, #11628, etc.
 			{
-				regionMinY = static_cast<int>(qMax(0.0, floor(current.yPos - (asce + offset))));
-				regionMaxY = static_cast<int>(floor(current.yPos + desc));
+				regionMinY = static_cast<int>(qMax(0.0, floor(current.yPos - (realAsce + offset))));
+				regionMaxY = static_cast<int>(floor(current.yPos + realDesc));
 			}
 
 			EndX = current.endOfLine(m_availableRegion, style.rightMargin(), regionMinY, regionMaxY);


### PR DESCRIPTION
I replace the asce and desc with realAsce and realDesc in the calculation of the last line only.
