### PR TITLE
fix #13938

### DIFF
--- a/scribus/pageitem_textframe.cpp
+++ b/scribus/pageitem_textframe.cpp
@@ -1257,7 +1257,7 @@ void PageItem_TextFrame::adjustParagraphEndings ()
 			// push this paragraph to the next frame
 			for (int i = 0; i < pull; ++i)
 				textLayout.removeLastLine();
-			MaxChars = textLayout.endOfFrame();
+			MaxChars = incompletePositions[incompleteLines-pull];
 			incompleteLines = 0;
 			incompletePositions.clear();
 		}


### PR DESCRIPTION
It turns out that first char is set to be MaxChars of first text frame which is wrong.
It should be last incompletePositions in the first frame.
