### PR TITLE
use QFontInfo to get accurate styleName

### DIFF
--- a/scribus/pageitem_group.cpp
+++ b/scribus/pageitem_group.cpp
@@ -25,6 +25,7 @@ for which a new license (GPL+exception) is in place.
 #include <cassert>
 
 #include <QApplication>
+#include <QFontInfo>
 
 #include "commonstrings.h"
 #include "pageitem_group.h"
@@ -124,7 +125,7 @@ void PageItem_Group::DrawObj_Item(ScPainter *p, QRectF /*e*/)
 			p->drawLine(FPoint(0, 0), FPoint(m_width, m_height));
 			p->drawLine(FPoint(0, m_height), FPoint(m_width, 0));
 			const QFont &font = QApplication::font();
-			p->setFont(PrefsManager::instance()->appPrefs.fontPrefs.AvailFonts.findFont(font.family(), font.styleName()), font.pointSizeF());
+			p->setFont(PrefsManager::instance()->appPrefs.fontPrefs.AvailFonts.findFont(font.family(), QFontInfo(font).styleName()), font.pointSizeF());
 			p->drawLine(FPoint(0, 0), FPoint(m_width, 0));
 			p->drawLine(FPoint(m_width, 0), FPoint(m_width, m_height));
 			p->drawLine(FPoint(m_width, m_height), FPoint(0, m_height));

--- a/scribus/pageitem_imageframe.cpp
+++ b/scribus/pageitem_imageframe.cpp
@@ -23,6 +23,7 @@ for which a new license (GPL+exception) is in place.
 
 // #include <QDebug>
 #include <QApplication>
+#include <QFontInfo>
 #include <QGridLayout>
 #include <QKeyEvent>
 
@@ -135,7 +136,7 @@ void PageItem_ImageFrame::DrawObj_Item(ScPainter *p, QRectF /*e*/)
 				p->drawLine(FPoint(0, 0), FPoint(m_width, m_height));
 				p->drawLine(FPoint(0, m_height), FPoint(m_width, 0));
 				const QFont &font = QApplication::font();
-				p->setFont(PrefsManager::instance()->appPrefs.fontPrefs.AvailFonts.findFont(font.family(), font.styleName()), font.pointSizeF());
+				p->setFont(PrefsManager::instance()->appPrefs.fontPrefs.AvailFonts.findFont(font.family(), QFontInfo(font).styleName()), font.pointSizeF());
 				p->drawText(QRectF(0.0, 0.0, m_width, m_height), htmlText);
 			}
 		}

--- a/scribus/pageitem_latexframe.cpp
+++ b/scribus/pageitem_latexframe.cpp
@@ -24,6 +24,7 @@ for which a new license (GPL+exception) is in place.
 #include "pageitem_latexframe.h"
 
 #include <QDebug>
+#include <QFontInfo>
 #include <QMessageBox>
 #include <QTemporaryFile>
 
@@ -128,7 +129,7 @@ void PageItem_LatexFrame::DrawObj_Item(ScPainter *p, QRectF e)
 		p->setPen(Qt::green, 1, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin);
 		p->drawLine(FPoint(0, 0), FPoint(m_width, m_height));
 		const QFont &font = QApplication::font();
-		p->setFont(PrefsManager::instance()->appPrefs.fontPrefs.AvailFonts.findFont(font.family(), font.styleName()), font.pointSizeF());
+		p->setFont(PrefsManager::instance()->appPrefs.fontPrefs.AvailFonts.findFont(font.family(), QFontInfo(font).styleName()), font.pointSizeF());
 		p->drawText(QRectF(0.0, 0.0, m_width, m_height), tr("Rendering..."));
 	}
 	else if (m_err)
@@ -139,7 +140,7 @@ void PageItem_LatexFrame::DrawObj_Item(ScPainter *p, QRectF e)
 		p->drawLine(FPoint(0, 0), FPoint(m_width, m_height));
 		p->drawLine(FPoint(0, m_height), FPoint(m_width, 0));
 		const QFont &font = QApplication::font();
-		p->setFont(PrefsManager::instance()->appPrefs.fontPrefs.AvailFonts.findFont(font.family(), font.styleName()), font.pointSizeF());
+		p->setFont(PrefsManager::instance()->appPrefs.fontPrefs.AvailFonts.findFont(font.family(), QFontInfo(font).styleName()), font.pointSizeF());
 		p->drawText(QRectF(0.0, 0.0, m_width, m_height), tr("Render Error"));
 	}
 	else

--- a/scribus/pageitem_symbol.cpp
+++ b/scribus/pageitem_symbol.cpp
@@ -25,6 +25,7 @@ for which a new license (GPL+exception) is in place.
 #include <cassert>
 
 #include <QApplication>
+#include <QFontInfo>
 
 #include "commonstrings.h"
 #include "pageitem.h"
@@ -66,7 +67,7 @@ void PageItem_Symbol::DrawObj_Item(ScPainter *p, QRectF /*e*/)
 			p->drawLine(FPoint(0, 0), FPoint(m_width, m_height));
 			p->drawLine(FPoint(0, m_height), FPoint(m_width, 0));
 			const QFont &font = QApplication::font();
-			p->setFont(PrefsManager::instance()->appPrefs.fontPrefs.AvailFonts.findFont(font.family(), font.styleName()), font.pointSizeF());
+			p->setFont(PrefsManager::instance()->appPrefs.fontPrefs.AvailFonts.findFont(font.family(), QFontInfo(font).styleName()), font.pointSizeF());
 			p->drawLine(FPoint(0, 0), FPoint(m_width, 0));
 			p->drawLine(FPoint(m_width, 0), FPoint(m_width, m_height));
 			p->drawLine(FPoint(m_width, m_height), FPoint(0, m_height));


### PR DESCRIPTION
In some fonts such as DejaVe Sans font there is no Regular style to fall back to. In that case, scribus will use the first font in Prefs.fontPrefs.AvailFonts.
Using Qfont().styleName() gives an empty style name while QFontInfo gives the accurate style name.
