### PR TITLE
fix selectWord to be aware of CTL

### DIFF
--- a/scribus/text/storytext.h
+++ b/scribus/text/storytext.h
@@ -29,6 +29,7 @@ pageitem.cpp  -  description
 #include <QString>
 #include <QList>
 #include <cassert>
+#include "unicode/brkiter.h"
 
 #include "marks.h"
 //#include "text/paragraphlayout.h"
@@ -277,6 +278,7 @@ private:
 private:
 	ScribusDoc * m_doc; 
 	int m_selFirst, m_selLast;
+	static BreakIterator* m_WordBreakIterator;
 //	int m_firstFrameItem, m_lastFrameItem;
 //	QList<LineSpec> m_lines;
 //	bool m_validLayout;


### PR DESCRIPTION
selectWord is used to select word when you double click on a text frame. Although, it works fine with RTL,
it fails to work with CJK, Thai, and east Asia languages. I tried to use QTextBoundaryFinder but it has
bugs with CJK so I move to ICU which it works fine.
This part of #166 
