### PR TITLE
Switch to UTF-32 internally

### DIFF
--- a/scribus/pageitem.cpp
+++ b/scribus/pageitem.cpp
@@ -2482,8 +2482,8 @@ QImage PageItem::DrawObj_toImage(QList<PageItem*> &emG, double scaling)
 QString PageItem::ExpandToken(uint base)
 {
 	//uint zae = 0;
-	QChar ch = itemText.text(base);
-	QString chstr = ch;
+	uint ch = itemText.text(base);
+	QString chstr = QString::fromUcs4(&ch, 1);
 	if (ch == SpecialChars::PAGENUMBER)
 	{
 		// compatibility mode: ignore subsequent pagenumber chars

--- a/scribus/pdflib_core.cpp
+++ b/scribus/pdflib_core.cpp
@@ -8838,7 +8838,7 @@ bool PDFLibCore::PDF_Annotation(PageItem *ite, uint PNr)
 	double x2 = x+ite->width();
 	double y2 = y-ite->height();
 	QString bmUtf16("");
-	if (!((ite->itemText.length() == 1) && (ite->itemText.text(0, 1) == QChar(13))))
+	if (!((ite->itemText.length() == 1) && (ite->itemText.text(0) == 13)))
 	{
 		// #6823 EncStringUTF16() perform the string encoding by its own
 		// via EncodeUTF16() so bmUtf16 must not encoded before

--- a/scribus/plugins/fileloader/scribus150format/scribus150format_save.cpp
+++ b/scribus/plugins/fileloader/scribus150format/scribus150format_save.cpp
@@ -78,7 +78,7 @@ QString Scribus150Format::saveElements(double xp, double yp, double wp, double h
 				continue;
 			for (int e = currItem->firstInFrame(); e <= currItem->lastInFrame(); ++e)
 			{
-				uint chr = currItem->itemText.text(e).unicode();
+				uint chr = currItem->itemText.text(e);
 				if (chr == 25)
 				{
                     if ((currItem->itemText.hasObject(e)) && (!emF.contains(currItem->itemText.object(e))))
@@ -1609,7 +1609,7 @@ void Scribus150Format::writeITEXTs(ScribusDoc *doc, ScXmlStreamWriter &docu, Pag
 	for (int k = 0; k < iTLen; ++k)
 	{
 		const CharStyle& style1(item->itemText.charStyle(k));
-		const QChar ch = item->itemText.text(k);
+		const uint ch = item->itemText.text(k);
 
 		if (ch == SpecialChars::OBJECT ||
 			ch == SpecialChars::TAB ||
@@ -1623,9 +1623,9 @@ void Scribus150Format::writeITEXTs(ScribusDoc *doc, ScXmlStreamWriter &docu, Pag
 			ch == SpecialChars::NBSPACE ||
 			ch == SpecialChars::ZWNBSPACE ||
 			ch == SpecialChars::ZWSPACE ||
-			ch.unicode() < 32 || 
-			(0xd800 <= ch.unicode() && ch.unicode() < 0xe000) ||
-			ch.unicode() == 0xfffe || ch.unicode() == 0xffff ||
+			ch < 32 ||
+			(0xd800 <= ch && ch < 0xe000) ||
+			ch == 0xfffe || ch == 0xffff ||
 			style1 != lastStyle)
 		{
 			// something new, write pending chars
@@ -1644,7 +1644,7 @@ void Scribus150Format::writeITEXTs(ScribusDoc *doc, ScXmlStreamWriter &docu, Pag
 			// each obj in its own ITEXT for now
 			docu.writeEmptyElement("ITEXT");
 			putCStyle(docu, lastStyle);
-			tmpnum.setNum(ch.unicode());
+			tmpnum.setNum(ch);
 			docu.writeAttribute("Unicode", tmpnum);
 			docu.writeAttribute("COBJ", item->itemText.object(k)->inlineCharID);
 		}
@@ -1703,13 +1703,13 @@ void Scribus150Format::writeITEXTs(ScribusDoc *doc, ScXmlStreamWriter &docu, Pag
 			docu.writeAttribute("name", "pgco");
 			putCStyle(docu, lastStyle);
 		}
-		else if (ch.unicode() < 32 || 
-				 (0xd800 <= ch.unicode() && ch.unicode() < 0xe000) ||
-				 ch.unicode() == 0xfffe || ch.unicode() == 0xffff)
+		else if (ch < 32 ||
+				 (0xd800 <= ch && ch < 0xe000) ||
+				 ch == 0xfffe || ch == 0xffff)
 		{
 			docu.writeEmptyElement("ITEXT");
 			putCStyle(docu, lastStyle);
-			tmpnum.setNum(ch.unicode());
+			tmpnum.setNum(ch);
 			docu.writeAttribute("Unicode", tmpnum);		
 		}
 		else

--- a/scribus/plugins/fileloader/scribus150format/scribus150format_save.cpp
+++ b/scribus/plugins/fileloader/scribus150format/scribus150format_save.cpp
@@ -1623,9 +1623,7 @@ void Scribus150Format::writeITEXTs(ScribusDoc *doc, ScXmlStreamWriter &docu, Pag
 			ch == SpecialChars::NBSPACE ||
 			ch == SpecialChars::ZWNBSPACE ||
 			ch == SpecialChars::ZWSPACE ||
-			ch < 32 ||
-			(0xd800 <= ch && ch < 0xe000) ||
-			ch == 0xfffe || ch == 0xffff ||
+			ch < 32 || ch == 0xfffe || ch == 0xffff ||
 			style1 != lastStyle)
 		{
 			// something new, write pending chars
@@ -1703,9 +1701,7 @@ void Scribus150Format::writeITEXTs(ScribusDoc *doc, ScXmlStreamWriter &docu, Pag
 			docu.writeAttribute("name", "pgco");
 			putCStyle(docu, lastStyle);
 		}
-		else if (ch < 32 ||
-				 (0xd800 <= ch && ch < 0xe000) ||
-				 ch == 0xfffe || ch == 0xffff)
+		else if (ch < 32 || ch == 0xfffe || ch == 0xffff)
 		{
 			docu.writeEmptyElement("ITEXT");
 			putCStyle(docu, lastStyle);

--- a/scribus/plugins/scriptplugin/cmdtext.cpp
+++ b/scribus/plugins/scriptplugin/cmdtext.cpp
@@ -257,11 +257,11 @@ PyObject *scribus_getframetext(PyObject* /* self */, PyObject* args)
 		if (it->HasSel)
 		{
 			if (it->itemText.selected(a))
-				text += it->itemText.text(a);
+				text += it->itemText.text(a, 1);
 		}
 		else
 		{
-			text += it->itemText.text(a);
+			text += it->itemText.text(a, 1);
 		}
 	}
 	return PyString_FromString(text.toUtf8());
@@ -290,11 +290,11 @@ PyObject *scribus_gettext(PyObject* /* self */, PyObject* args)
 		if (it->HasSel)
 		{
 			if (it->itemText.selected(a))
-				text += it->itemText.text(a);
+				text += it->itemText.text(a, 1);
 		}
 		else
 		{
-			text += it->itemText.text(a);
+			text += it->itemText.text(a, 1);
 		}
 	} // for
 	return PyString_FromString(text.toUtf8());

--- a/scribus/plugins/short-words/parse.cpp
+++ b/scribus/plugins/short-words/parse.cpp
@@ -114,8 +114,9 @@ void SWParse::parseItem(PageItem *aFrame)
 	// return text into frame
 	for (i=0; i < aFrame->itemText.length() && ! aFrame->frameDisplays(i); ++i)
 		;
+	QVector<uint> uContent = content.toUcs4();
 	for (; i < aFrame->itemText.length() && aFrame->frameDisplays(i); ++i)
-		aFrame->itemText.replaceChar(i, content.at(i));
+		aFrame->itemText.replaceChar(i, uContent.at(i));
 	if (content.count(SpecialChars::NBSPACE) > changes)
 		++modify;
 

--- a/scribus/pslib.cpp
+++ b/scribus/pslib.cpp
@@ -1948,9 +1948,9 @@ bool PSLib::ProcessItem(ScribusDoc* Doc, ScPage* a, PageItem* c, uint PNr, bool 
 				QString cc;
 				for (int d = 0; d < c->itemText.length(); ++d)
 				{
-					if ((c->itemText.text(d) == QChar(13)) || (c->itemText.text(d) == QChar(10)) || (c->itemText.text(d) == QChar(28)))
+					if ((c->itemText.text(d) == 13) || (c->itemText.text(d) == 10) || (c->itemText.text(d) == 28))
 						break;
-					bm += "\\"+cc.setNum(qMax(c->itemText.text(d).unicode(), (ushort) 32), 8);
+					bm += "\\"+cc.setNum(qMax(c->itemText.text(d), (uint) 32), 8);
 				}
 				PDF_Bookmark(bm, a->pageNr()+1);
 			}
@@ -1962,7 +1962,7 @@ bool PSLib::ProcessItem(ScribusDoc* Doc, ScPage* a, PageItem* c, uint PNr, bool 
 					QString cc;
 					for (int d = 0; d < c->itemText.length(); ++d)
 					{
-						bm += "\\"+cc.setNum(qMax(c->itemText.text(d).unicode(), (ushort) 32), 8);
+						bm += "\\"+cc.setNum(qMax(c->itemText.text(d), (uint) 32), 8);
 					}
 					PDF_Annotation(c, bm, 0, 0, c->width(), -c->height());
 				}

--- a/scribus/sctextstruct.h
+++ b/scribus/sctextstruct.h
@@ -81,11 +81,11 @@ public:
 	ParagraphStyle* parstyle; // only for parseps
 	int embedded;
 	Mark* mark;
-	QChar ch;
+	uint ch;
 	ScText() :
 		CharStyle(),
 		parstyle(NULL),
-		embedded(0), mark(NULL), ch() {}
+		embedded(0), mark(NULL), ch(0) {}
 	ScText(const ScText& other) :
 		CharStyle(other),
 		parstyle(NULL),

--- a/scribus/text/sctext_shared.cpp
+++ b/scribus/text/sctext_shared.cpp
@@ -132,7 +132,7 @@ void ScText_Shared::replaceCharStyleContextInParagraph(int pos, const StyleConte
 	while ( it.hasNext() ) {
 		ScText* elem = it.next();
 		assert( elem );
-		if ( elem->ch.isNull() ) 
+		if ( elem->ch == 0 )
 		{
 			// nothing, see code in removeParSep
 		}

--- a/scribus/text/specialchars.cpp
+++ b/scribus/text/specialchars.cpp
@@ -43,17 +43,17 @@ QChar SpecialChars::PAGECOUNT    = QChar(23);
 QChar SpecialChars::BLANK        = QChar(32);      // SPACE is some macro on my machine - av
 
 
-bool SpecialChars::isBreakingSpace(QChar c)
+bool SpecialChars::isBreakingSpace(uint c)
 {
 	return c == BLANK || c == ZWSPACE;
 }
 
-bool SpecialChars::isExpandingSpace(QChar c)
+bool SpecialChars::isExpandingSpace(uint c)
 {
 	return c == BLANK || c == NBSPACE;
 }
 
-bool SpecialChars::isBreak(QChar c, bool includeColBreak)
+bool SpecialChars::isBreak(uint c, bool includeColBreak)
 {
 	return (c == PARSEP 
 			|| c == LINEBREAK 
@@ -61,7 +61,7 @@ bool SpecialChars::isBreak(QChar c, bool includeColBreak)
 			|| (includeColBreak && c == COLBREAK));
 }
 
-int SpecialChars::getCJKAttr(QChar c)
+int SpecialChars::getCJKAttr(uint code)
 {
 	static uchar attr_3000[0x100] = {
 		// 0x3000 - 0x3007
@@ -159,7 +159,6 @@ int SpecialChars::getCJKAttr(QChar c)
 		// 0xff60
 		CJK_FENCE_END
 	};
-	ushort code = c.unicode();
 	if(code >= 0x3100 && code < 0xa000){
 		return CJK_KANJI;
 	}

--- a/scribus/text/specialchars.h
+++ b/scribus/text/specialchars.h
@@ -50,9 +50,9 @@ public:
 	static QChar PAGECOUNT;
 	static QChar BLANK;
 	
-	static bool isBreak(QChar c, bool includeColBreak = true);
-	static bool isBreakingSpace(QChar c);
-	static bool isExpandingSpace(QChar c);
+	static bool isBreak(uint c, bool includeColBreak = true);
+	static bool isBreakingSpace(uint c);
+	static bool isExpandingSpace(uint c);
 
 		enum {
 			CJK_FENCE_BEGIN = 0x0001,
@@ -75,7 +75,7 @@ public:
 			CJK_NOBREAK_BEFORE = 0x0100,
 			CJK_NOBREAK_AFTER = 0x0200,
 		};
-		static int getCJKAttr(QChar c);
+	static int getCJKAttr(uint c);
 
 	static bool isCJK(uint ch);
 };

--- a/scribus/text/storytext.cpp
+++ b/scribus/text/storytext.cpp
@@ -607,7 +607,10 @@ void StoryText::insertChars(int pos, QVector<uint> txt, bool applyNeighbourStyle
 
 	for (int i = 0; i < txt.length(); ++i) {
 		ScText * item = new ScText(clone);
-		item->ch= txt.at(i);
+		uint ch = txt.at(i);
+		if (QChar::isNonCharacter(ch) || QChar::isSurrogate(ch) || ch > QChar::LastValidCodePoint)
+			ch = QChar::ReplacementCharacter;
+		item->ch = ch;
 		item->setContext(cStyleContext);
 		d->insert(pos + i, item);
 		d->len++;

--- a/scribus/text/storytext.h
+++ b/scribus/text/storytext.h
@@ -102,7 +102,7 @@ class SCRIBUS_API StoryText : public QObject, public SaxIO
 
 	// Find text in story
 	int indexOf(const QString &str, int from = 0, Qt::CaseSensitivity cs = Qt::CaseSensitive) const;
-	int indexOf(QChar ch, int from = 0, Qt::CaseSensitivity cs = Qt::CaseSensitive) const;
+	int indexOf(uint ch, int from = 0, Qt::CaseSensitivity cs = Qt::CaseSensitive) const;
 	
 	// Add, change, replace
 	// Insert chars from another StoryText object at current cursor position
@@ -118,14 +118,15 @@ class SCRIBUS_API StoryText : public QObject, public SaxIO
 	// Insert chars at current cursor position
 	void insertChars(QString txt, bool applyNeighbourStyle = false);
 	// Insert chars ar specific position
- 	void insertChars(int pos, QString txt, bool applyNeighbourStyle = false);
+	void insertChars(int pos, QString txt, bool applyNeighbourStyle = false);
+	void insertChars(int pos, QVector<uint> txt, bool applyNeighbourStyle = false);
 	// Insert inline object at current cursor position
 	void insertObject(int obj);
 	// Insert object at specific position
 	void insertObject(int pos, int obj);
 	// Insert mark at cursor or specific position
 	void insertMark(Mark* Mark, int pos = -1);
- 	void replaceChar(int pos, QChar ch);
+	void replaceChar(int pos, uint ch);
  	// Replaced a word, and return the difference in length between old and new
 	int replaceWord(int pos, QString newWord);
 	void replaceObject(int pos, int obj);
@@ -142,9 +143,9 @@ class SCRIBUS_API StoryText : public QObject, public SaxIO
 	QString plainText() const;
 
 	// Get char at current cursor position
-	QChar   text() const;
+	uint text() const;
 	// Get char at specific position
- 	QChar   text(int pos) const;
+	uint text(int pos) const;
 	// Get text with len chars at specific position
  	QString text(int pos, uint len) const;
  	//Get sentence at any position within it
@@ -155,9 +156,6 @@ class SCRIBUS_API StoryText : public QObject, public SaxIO
     bool hasMark(int pos, Mark* mrk = NULL) const;
 	Mark *mark(int pos) const;
     void replaceMark(int pos, Mark* mrk);
-
-	bool isHighSurrogate(int pos) const;
-	bool isLowSurrogate(int pos) const;
 
 	// Get charstyle at current cursor position
 	const CharStyle& charStyle() const;
@@ -265,7 +263,6 @@ signals:
 private:
  	ScText * item(uint index);
  	const ScText * item(uint index) const;
-	void fixSurrogateSelection();
 
 //public:
 //	ScText * item_p(uint index) { return item(index); }

--- a/scribus/text/textlayout.cpp
+++ b/scribus/text/textlayout.cpp
@@ -290,7 +290,7 @@ QLineF TextLayout::positionToPoint(int pos) const
 			Box* column = m_box->boxes().last();
 			Box* line = column->boxes().last();
 			Box* glyph = line->boxes().last();
-			QChar ch = story()->text(line->lastChar());
+			uint ch = story()->text(line->lastChar());
 			if (ch == SpecialChars::PARSEP || ch == SpecialChars::LINEBREAK)
 			{
 				// last character is a newline, draw the cursor on the next line.

--- a/scribus/text/textshaper.cpp
+++ b/scribus/text/textshaper.cpp
@@ -28,10 +28,10 @@ TextShaper::TextShaper(StoryText &story, int first)
 {
 	for (int i = m_firstChar; i < m_story.length(); ++i)
 	{
-		QChar ch = m_story.text(i);
+		uint ch = m_story.text(i);
 		if (ch == SpecialChars::PARSEP || ch == SpecialChars::LINEBREAK)
 			continue;
-		QString str(ch);
+		QString str = QString::fromUcs4(&ch, 1);
 		m_textMap.insert(i, i);
 		m_text.append(str);
 	}
@@ -168,7 +168,7 @@ void TextShaper::buildText(QVector<int>& smallCaps)
 	{
 		if (m_singlePar)
 		{
-			QChar ch = m_story.text(i);
+			uint ch = m_story.text(i);
 			if (ch == SpecialChars::PARSEP || ch == SpecialChars::LINEBREAK)
 				continue;
 		}
@@ -442,7 +442,7 @@ QList<GlyphCluster> TextShaper::shape()
 			int firstChar = m_textMap.value(firstCluster);
 			int lastChar = m_textMap.value(nextCluster - 1);
 
-			QChar ch = m_story.text(firstChar);
+			uint ch = m_story.text(firstChar);
 			LayoutFlags flags = m_story.flags(firstChar);
 			const CharStyle& charStyle(m_story.charStyle(firstChar));
 			const StyleFlag& effects = charStyle.effects();
@@ -466,12 +466,12 @@ QList<GlyphCluster> TextShaper::shape()
 
 			if (effects & ScStyle_Underline)
 				run.setFlag(ScLayout_Underlined);
-			if (effects & ScStyle_UnderlineWords && !ch.isSpace())
+			if (effects & ScStyle_UnderlineWords && !QChar::isSpace(ch))
 				run.setFlag(ScLayout_Underlined);
 
 			if (firstChar != 0 &&
-			    SpecialChars::isCJK(m_story.text(firstChar).unicode()) &&
-			    SpecialChars::isCJK(m_story.text(firstChar - 1).unicode()))
+			    SpecialChars::isCJK(m_story.text(firstChar)) &&
+			    SpecialChars::isCJK(m_story.text(firstChar - 1)))
 				run.setFlag(ScLayout_ImplicitSpace);
 
 			run.setScaleH(charStyle.scaleH() / 1000.0);
@@ -485,7 +485,7 @@ QList<GlyphCluster> TextShaper::shape()
 				    (ch == SpecialChars::LINEBREAK || ch == SpecialChars::PARSEP ||
 				     ch == SpecialChars::FRAMEBREAK || ch == SpecialChars::COLBREAK))
 				{
-					gl.glyph = scFace.emulateGlyph(ch.unicode());
+					gl.glyph = scFace.emulateGlyph(ch);
 				}
 
 				if (gl.glyph < ScFace::CONTROL_GLYPHS)

--- a/scribus/ui/bookmwin.cpp
+++ b/scribus/ui/bookmwin.cpp
@@ -135,18 +135,18 @@ void BookMView::AddPageItem(PageItem* ite)
 {
 	QString bm = "";
 	QString bm2 = "";
-	QString cc;
+	uint cc;
 	for (int d = 0; d < ite->itemText.length(); ++d)
 	{
 		cc = ite->itemText.text(d);
-		if ((cc == QChar(13)) || (cc == QChar(10)))
+		if ((cc == 13) || (cc == 10))
 			break;
-		if (cc == QChar(29))
-			cc = " ";
-		if ((cc == "(") || (cc == ")") || (cc == "\\"))
+		if (cc == 29)
+			cc = ' ';
+		if ((cc == '(') || (cc == ')') || (cc == '\\'))
 			bm2 += "\\";
-		bm += cc;
-		bm2 += cc;
+		bm += QString::fromUcs4(&cc, 1);
+		bm2 += QString::fromUcs4(&cc, 1);
 	}
 	AddItem(bm, bm2, ite);
 	Last = NrItems;
@@ -278,16 +278,16 @@ void BookMView::ChangeText(PageItem *currItem)
 	BookMItem *ite;
 	QString bm = "";
 	QString bm2 = "";
-	QString cc;
+	uint cc;
 	for (int d = 0; d < currItem->itemText.length(); ++d)
 	{
 		cc = currItem->itemText.text(d);
-		if ((cc == QChar(13)) || (cc == QChar(10)))
+		if ((cc == 13) || (cc == 10))
 			break;
-		if ((cc == "(") || (cc == ")") || (cc == "\\"))
+		if ((cc == '(') || (cc == ')') || (cc == '\\'))
 			bm2 += "\\";
-		bm += cc;
-		bm2 += cc;
+		bm += QString::fromUcs4(&cc, 1);
+		bm2 += QString::fromUcs4(&cc, 1);
 	}
 	QTreeWidgetItemIterator it(this);
 	while (*it)

--- a/scribus/ui/search.cpp
+++ b/scribus/ui/search.cpp
@@ -446,12 +446,12 @@ void SearchReplace::slotDoSearch()
 				found = (a >= 0);
 				if (!found) break;
 
-				if (Word->isChecked() && (a > 0) && !m_item->itemText.text(a - 1).isSpace())
+				if (Word->isChecked() && (a > 0) && !QChar::isSpace(m_item->itemText.text(a - 1)))
 					found = false;
 				if (Word->isChecked())
 				{
 					int lastChar = qMin(a + sText.length(), maxChar);
-					found = ((lastChar == maxChar) || m_item->itemText.text(lastChar).isSpace());
+					found = ((lastChar == maxChar) || QChar::isSpace(m_item->itemText.text(lastChar)));
 				}
 				if (!found) continue;
 			}
@@ -679,13 +679,13 @@ void SearchReplace::slotDoReplace()
 {
 	if (m_itemMode)
 	{
-		QString repl, sear;
+		QVector<uint> repl, sear;
 		int cs, cx;
 // 		ScText *hg;
 		if (RText->isChecked())
 		{
-			repl = RTextVal->text();
-			sear = STextVal->text();
+			repl = RTextVal->text().toUcs4();
+			sear = STextVal->text().toUcs4();
 			if (sear.length() == repl.length())
 			{
 				for (cs = 0; cs < sear.length(); ++cs)

--- a/scribus/ui/storyeditor.cpp
+++ b/scribus/ui/storyeditor.cpp
@@ -740,7 +740,7 @@ void SEditor::insertUpdate(int position, int len)
 	for (int pos = position; pos < end; ++pos)
 	{
 		const CharStyle& cstyle(StyledText.charStyle(pos));
-		const QChar ch = StyledText.text(pos);
+		uint ch = StyledText.text(pos);
 		if (ch == SpecialChars::PARSEP)
 		{
 			text += "\n";
@@ -820,7 +820,7 @@ void SEditor::insertUpdate(int position, int len)
 			setColor(false);
 		}
 		else
-			text += ch;
+			text += QString::fromUcs4(&ch, 1);
 	}
 	if (position < end)
 	{

--- a/scribus/util.cpp
+++ b/scribus/util.cpp
@@ -360,7 +360,8 @@ bool overwrite(QWidget *parent, QString filename)
 
 void WordAndPara(PageItem* currItem, int *w, int *p, int *c, int *wN, int *pN, int *cN)
 {
-	QChar Dat = QChar(32);
+	// FIXME HOST: use break iterators here
+	uint Dat = 32;
 	int para = 0;
 	int ww = 0;
 	int cc = 0;
@@ -381,12 +382,12 @@ void WordAndPara(PageItem* currItem, int *w, int *p, int *c, int *wN, int *pN, i
 	{
 		for (int a = qMax(nextItem->firstInFrame(),0); a <= nextItem->lastInFrame() && a < nextItem->itemText.length(); ++a)
 		{
-			QChar b = nextItem->itemText.text(a);
+			uint b = nextItem->itemText.text(a);
 			if (b == SpecialChars::PARSEP)
 			{
 				para++;
 			}
-			if ((!b.isLetterOrNumber()) && (Dat.isLetterOrNumber()) && (!first))
+			if ((!QChar::isLetterOrNumber(b)) && (QChar::isLetterOrNumber(Dat)) && (!first))
 			{
 				ww++;
 			}
@@ -401,12 +402,12 @@ void WordAndPara(PageItem* currItem, int *w, int *p, int *c, int *wN, int *pN, i
 		paraN++;
 		for (int a = nbl->lastInFrame()+1; a < nbl->itemText.length(); ++a)
 		{
-			QChar b = nbl->itemText.text(a);
+			uint b = nbl->itemText.text(a);
 			if (b == SpecialChars::PARSEP)
 			{
 				paraN++;
 			}
-			if ((!b.isLetterOrNumber()) && (Dat.isLetterOrNumber()) && (!first))
+			if ((!QChar::isLetterOrNumber(b)) && (QChar::isLetterOrNumber(Dat)) && (!first))
 			{
 				wwN++;
 			}
@@ -418,7 +419,7 @@ void WordAndPara(PageItem* currItem, int *w, int *p, int *c, int *wN, int *pN, i
 	else {
 		para++;
 	}
-	if (Dat.isLetterOrNumber())
+	if (QChar::isLetterOrNumber(Dat))
 	{
 		if (nbl->frameOverflows())
 			wwN++;


### PR DESCRIPTION
This PR witches `ScText` class to use UTF-32 code units instead of `QChar` which is 16-bit. This simplifies the handling of text outside BMP and keep the assumption all over the place that `ScText` represents a single character, instead of having to deal with surrogate pairs everywhere.

This has the side effect of fixing #197.

This is rather an invasive change, so I appreciate if others can review and test it.
