### PR TITLE
Include the Tcl/Tk dependencies that are needed for script GUIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
       qt56tools libgraphicsmagick++1-dev
       libopenscenegraph-dev libpoppler-dev libcairo2-dev libwpg-dev libmspub-dev
       libcdr-dev libvisio-dev libharfbuzz-dev libharfbuzz-icu0
-      coreutils binutils python-tk;
+      coreutils binutils;
     fi
 # OSX
 # - if [ $TRAVIS_OS_NAME == osx ]; then brew --env && brew config && brew list; fi

--- a/AppImage-package/bundle.sh
+++ b/AppImage-package/bundle.sh
@@ -20,11 +20,16 @@ cd $HOME/$APP/
 wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
 . ./functions.sh
 
+URLS=$(apt-get install -qq --reinstall --print-uris  python-tk | cut -d "'" -f 2)
+wget $URLS
+
 cd $APP.AppDir
 
 ########################################################################
 # Copy desktop and icon file to AppDir for AppRun to pick them up
 ########################################################################
+
+find ../*.deb -exec dpkg -x {} . \;
 
 get_apprun
 


### PR DESCRIPTION
To prevent 

```
Traceback (most recent call last):
  File "<string>", line 10, in <module>
  File "././/share/scribus/scripts/FontSample.py", line 1577, in <module>
    main_wrapper(sys.argv)
  File "././/share/scribus/scripts/FontSample.py", line 1562, in main_wrapper
    main(argv)
  File "././/share/scribus/scripts/FontSample.py", line 1551, in main
    initialisation()
  File "././/share/scribus/scripts/FontSample.py", line 1544, in initialisation
    app = setup_tk()
  File "././/share/scribus/scripts/FontSample.py", line 1512, in setup_tk
    root = Tk()
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 1818, in __init__
    self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
TclError: Can't find a usable init.tcl in the following directories: 
    /usr/share/tcltk/tcl8.6 /usr/lib/tcl8.6 /lib/tcl8.6 /usr/library /library /tcl8.6.1/library /tcl8.6.1/library

/usr/share/tcltk/tcl8.6/init.tcl: version conflict for package "Tcl": have 8.6.1, need exactly 8.6.5
version conflict for package "Tcl": have 8.6.1, need exactly 8.6.5
    while executing
"package require -exact Tcl 8.6.5"
    (file "/usr/share/tcltk/tcl8.6/init.tcl" line 19)
    invoked from within
"source /usr/share/tcltk/tcl8.6/init.tcl"
    ("uplevel" body line 1)
    invoked from within
"uplevel #0 [list source $tclfile]"
```
