### PR TITLE
Fix CTL #207: insert kerning between CJK letters and only Latin letters

### DIFF
--- a/scribus/text/specialchars.cpp
+++ b/scribus/text/specialchars.cpp
@@ -209,6 +209,32 @@ bool SpecialChars::isCJK(uint ch)
 		return false;
 }
 
+
+bool SpecialChars::isLetterRequiringSpaceAroundCJK(uint ch) {
+	return (0x0030 <= ch && ch <= 0x0039) ||  // ASCII digits
+		   (0x0041 <= ch && ch <= 0x005A) ||  // Latin uppercase alphabet
+		   (0x0061 <= ch && ch <= 0x007A) ||  // Latin lowercase alphabet
+		   (0x00C0 <= ch && ch <= 0x00D6) ||  // Letters in Latin-1 Supplement
+		   (0x00D8 <= ch && ch <= 0x00F6) ||  // Letters in Latin-1 Supplement
+		   (0x00F8 <= ch && ch <= 0x00FF) ||  // Letters in Latin-1 Supplement
+		   (0x0100 <= ch && ch <= 0x017F) ||  // Letters in Latin Extended-A
+		   (0x0180 <= ch && ch <= 0x024F) ||  // Letters in Latin Extended-B
+		   (0x0250 <= ch && ch <= 0x02AF) ||  // Letters in IPA Extensions
+		   (0x1D00 <= ch && ch <= 0x1D25) ||  // Letters in Phonetic Extentions
+		   (0x1D6B <= ch && ch <= 0x1D70) ||  // Letters in Phonetic Extentions
+		   (0x1D80 <= ch && ch <= 0x1D9A) ||  // Letters in Phonetic Extentions Supplement
+		   (0x1E02 <= ch && ch <= 0x1EF3) ||  // Letters in Latin Extended Additional
+		   (0x2C60 <= ch && ch <= 0x2C7F) ||  // Letters in Latin Extended-C
+		   (0xA722 <= ch && ch <= 0xA787) ||  // Letters in Latin Extended-D
+		   (0xA78B <= ch && ch <= 0xA7AE) ||  // Letters in Latin Extended-D
+		   (0xA7B0 <= ch && ch <= 0xA7B7) ||  // Letters in Latin Extended-D
+		   (0xA7F7 <= ch && ch <= 0xA7BF) ||  // Letters in Latin Extended-D
+		   (0xAB30 <= ch && ch <= 0xAB5A) ||  // Letters in Latin Extended-D
+		   (0xAB5C <= ch && ch <= 0xAB64) ||  // Letters in Latin Extended-D
+		   (0xFB00 <= ch && ch <= 0xFB06) ;   // Alphabetic Presentation Forms
+}
+
+
 bool SpecialChars::isIgnorableCodePoint(uint ch)
 {
 	// based on list of Default_Ignorable_Code_Point in Unicode 9

--- a/scribus/text/specialchars.h
+++ b/scribus/text/specialchars.h
@@ -78,6 +78,7 @@ public:
 		static int getCJKAttr(QChar c);
 
 	static bool isCJK(uint ch);
+	static bool isLetterRequiringSpaceAroundCJK(uint ch);
 	static bool isIgnorableCodePoint(uint ch);
 };
 

--- a/scribus/text/textshaper.cpp
+++ b/scribus/text/textshaper.cpp
@@ -499,61 +499,26 @@ ShapedText TextShaper::shape(int fromPos, int toPos)
 
 				int currStat = SpecialChars::getCJKAttr(m_story.text(lastChar));
 				int nextStat = SpecialChars::getCJKAttr(m_story.text(lastChar + 1));
+
+				// 1. add 1/4 aki (space) between a CJK letter and
+				//    - a latin letter
+				//    - an ASCII Digits
 				if (currStat != 0)
-				{	// current char is CJK
-					if (nextStat == 0
-							&& !SpecialChars::isBreakingSpace(m_story.text(lastChar + 1))
-							&& SpecialChars::isCJK(m_story.text(lastChar + 1).unicode())) {
+				{
+					// current char is CJK
+					if (SpecialChars::isLetterRequiringSpaceAroundCJK(m_story.text(lastChar + 1).unicode())) {
 						switch(currStat & SpecialChars::CJK_CHAR_MASK) {
 						case SpecialChars::CJK_KANJI:
 						case SpecialChars::CJK_KANA:
 						case SpecialChars::CJK_NOTOP:
 							run.extraWidth += quarterEM;
 						}
-					} else {	// next char is CJK, too
-						switch(currStat & SpecialChars::CJK_CHAR_MASK) {
-						case SpecialChars::CJK_FENCE_END:
-							switch(nextStat & SpecialChars::CJK_CHAR_MASK) {
-							case SpecialChars::CJK_FENCE_BEGIN:
-							case SpecialChars::CJK_FENCE_END:
-							case SpecialChars::CJK_COMMA:
-							case SpecialChars::CJK_PERIOD:
-							case SpecialChars::CJK_MIDPOINT:
-								run.extraWidth -= halfEM;
-							}
-							break;
-						case SpecialChars::CJK_COMMA:
-						case SpecialChars::CJK_PERIOD:
-							switch(nextStat & SpecialChars::CJK_CHAR_MASK) {
-							case SpecialChars::CJK_FENCE_BEGIN:
-							case SpecialChars::CJK_FENCE_END:
-								run.extraWidth -= halfEM;;
-							}
-							break;
-						case SpecialChars::CJK_MIDPOINT:
-							switch(nextStat & SpecialChars::CJK_CHAR_MASK) {
-							case SpecialChars::CJK_FENCE_BEGIN:
-								run.extraWidth -= halfEM;
-							}
-							break;
-						case SpecialChars::CJK_FENCE_BEGIN:
-							int prevStat = SpecialChars::getCJKAttr(m_story.text(lastChar - 1));
-							if ((prevStat & SpecialChars::CJK_CHAR_MASK) == SpecialChars::CJK_FENCE_BEGIN)
-							{
-								run.extraWidth -= halfEM;
-								run.xoffset -= halfEM;
-							}
-							else
-							{
-								run.setFlag(ScLayout_CJKFence);
-							}
-							break;
-						}
 					}
-				} else {	// current char is not CJK
-					if (nextStat != 0
-							&& !SpecialChars::isBreakingSpace(m_story.text(lastChar))
-							&& !SpecialChars::isCJK(m_story.text(lastChar + 1).unicode())) {
+				}
+				else
+				{
+					// current char is not CJK
+					if (SpecialChars::isLetterRequiringSpaceAroundCJK(m_story.text(lastChar).unicode())) {
 						switch(nextStat & SpecialChars::CJK_CHAR_MASK) {
 						case SpecialChars::CJK_KANJI:
 						case SpecialChars::CJK_KANA:
@@ -561,6 +526,49 @@ ShapedText TextShaper::shape(int fromPos, int toPos)
 							// use the size of the current char instead of the next one
 							run.extraWidth += quarterEM;
 						}
+					}
+				}
+
+				// 2. remove spaces from glyphs with the following CJK attributes
+				if (currStat != 0)
+				{	// current char is CJK
+					switch(currStat & SpecialChars::CJK_CHAR_MASK) {
+					case SpecialChars::CJK_FENCE_END:
+						switch(nextStat & SpecialChars::CJK_CHAR_MASK) {
+						case SpecialChars::CJK_FENCE_BEGIN:
+						case SpecialChars::CJK_FENCE_END:
+						case SpecialChars::CJK_COMMA:
+						case SpecialChars::CJK_PERIOD:
+						case SpecialChars::CJK_MIDPOINT:
+							run.extraWidth -= halfEM;
+						}
+						break;
+					case SpecialChars::CJK_COMMA:
+					case SpecialChars::CJK_PERIOD:
+						switch(nextStat & SpecialChars::CJK_CHAR_MASK) {
+						case SpecialChars::CJK_FENCE_BEGIN:
+						case SpecialChars::CJK_FENCE_END:
+							run.extraWidth -= halfEM;;
+						}
+						break;
+					case SpecialChars::CJK_MIDPOINT:
+						switch(nextStat & SpecialChars::CJK_CHAR_MASK) {
+						case SpecialChars::CJK_FENCE_BEGIN:
+							run.extraWidth -= halfEM;
+						}
+						break;
+					case SpecialChars::CJK_FENCE_BEGIN:
+						int prevStat = SpecialChars::getCJKAttr(m_story.text(lastChar - 1));
+						if ((prevStat & SpecialChars::CJK_CHAR_MASK) == SpecialChars::CJK_FENCE_BEGIN)
+						{
+							run.extraWidth -= halfEM;
+							run.xoffset -= halfEM;
+						}
+						else
+						{
+							run.setFlag(ScLayout_CJKFence);
+						}
+						break;
 					}
 				}
 			}


### PR DESCRIPTION
This change limit the set of characters that requires kerning (1/4 space)
before/after CJK characters following a common Japanese typeset rule.

The reason for limiting it to Latin is that there are many non CJK characters
that should not require such kerning.

This change no longer add kerning between CJK and Arabic
letters, for example; Users need to manually insert space between
them. However, since such a situation does not occurs frequently,
this change would be acceptable.